### PR TITLE
Trim trailing empty line from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,3 +218,4 @@ Class | Method | HTTP request | Description
 - [RecognizeBase64Request](docs/RecognizeBase64Request.md)
 - [RegionPoint](docs/RegionPoint.md)
 - [ScanBase64Request](docs/ScanBase64Request.md)
+

--- a/scripts/docs_format.sh
+++ b/scripts/docs_format.sh
@@ -7,6 +7,7 @@ format_md_file () {
 }
 
 format_md_file "README.md"
+sed -i -e '${/^$/d;}' "README.md"
 
 for filename in ./docs/*.md; do
   format_md_file "$filename"


### PR DESCRIPTION
## Summary
- Add trailing empty line trimming to `docs_format.sh` for README.md

## Test plan
- [ ] Verify `scripts/docs_format.sh` runs successfully
- [ ] Verify README.md has no trailing empty line after generation