### PR TITLE
Fix insert-example adding extra trailing newline

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,4 +218,3 @@ Class | Method | HTTP request | Description
 - [RecognizeBase64Request](docs/RecognizeBase64Request.md)
 - [RegionPoint](docs/RegionPoint.md)
 - [ScanBase64Request](docs/ScanBase64Request.md)
-

--- a/scripts/docs_format.sh
+++ b/scripts/docs_format.sh
@@ -7,7 +7,6 @@ format_md_file () {
 }
 
 format_md_file "README.md"
-sed -i -e '${/^$/d;}' "README.md"
 
 for filename in ./docs/*.md; do
   format_md_file "$filename"


### PR DESCRIPTION
## Summary
- Remove redundant sed from `docs_format.sh` (runs before `insert-examples`, ineffective)
- Remove trailing empty line from README.md

## Test plan
- [ ] Run `make after-gen` and verify README.md has no trailing empty line